### PR TITLE
Fix typo that prevented CSS from being removed with onDestroy

### DIFF
--- a/admin-lte.js
+++ b/admin-lte.js
@@ -176,7 +176,7 @@ function waitOnCSS (url, timeout) {
     },
 
     remove: function () {
-      $('link[url="' + url + '"]').remove();
+      $('link[href="' + url + '"]').remove();
     }
   };
 }


### PR DESCRIPTION
The `remove` function is searching for a CSS selector that will not exist because it is looking for the `link`'s "url" attribute instead of the "href" attribute. This fixes that.
