### PR TITLE
Replace deprecated `isAsset` option to `addFiles` with `addAssets`

### DIFF
--- a/package.js
+++ b/package.js
@@ -19,7 +19,7 @@ Package.onUse(function(api) {
     'admin-lte.js'
   ], 'client');
 
-  api.addFiles([
+  api.addAssets([
     'css/AdminLTE.min.css',
     'css/skins/skin-black-light.min.css',
     'css/skins/skin-black.min.css',
@@ -33,5 +33,5 @@ Package.onUse(function(api) {
     'css/skins/skin-red.min.css',
     'css/skins/skin-yellow-light.min.css',
     'css/skins/skin-yellow.min.css'
-  ], 'client', { isAsset: true });
+  ], 'client');
 });


### PR DESCRIPTION
Fixes the following error when you try to add the package

=> Errors while initializing project:         

While reading package from `/Users/larson/Development/website/packages/meteor-admin-lte`:
package.js:22:7: The `isAsset` option to `addFiles` is deprecated. Use PackageAPI#addAssets instead.
