### PR TITLE
Fix broken style when accessing internal site from outside or vice versa

### DIFF
--- a/admin-lte.js
+++ b/admin-lte.js
@@ -121,12 +121,11 @@ Template.AdminLTE.events({
 });
 
 function cssUrl () {
-  return Meteor.absoluteUrl('packages/mfactory_admin-lte/css/AdminLTE.min.css');
+  return '/packages/mfactory_admin-lte/css/AdminLTE.min.css';
 }
 
 function skinUrl (name) {
-  return Meteor.absoluteUrl(
-    'packages/mfactory_admin-lte/css/skins/skin-' + name + '.min.css');
+  return '/packages/mfactory_admin-lte/css/skins/skin-' + name + '.min.css';
 }
 
 function waitOnCSS (url, timeout) {


### PR DESCRIPTION
Replaces the css urls with relative paths only instead of absolute urls. This fixes a case for me where I have a meteor instance that is accessible from within a company network by its local address while it is accessible from outside the network only by its public ip address.   There is no difference in other cases I think.
